### PR TITLE
Store the api key in the plugin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ vendor/
 .idea
 
 *.phpunit.result.cache
+
+odoo_conn.key

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,7 @@ services:
   wordpress:
     image: wordpress:apache
     restart: always
+    user: 1000:1000
     ports:
       - 8080:80
     environment:

--- a/encryption.php
+++ b/encryption.php
@@ -8,7 +8,7 @@ class OdooConnEncryptionFileHandler
 
     public function __construct()
     {
-        $this->encryption_key_path = ABSPATH . "odoo_conn.key";
+        $this->encryption_key_path = plugin_dir_path(__FILE__) . "odoo_conn.key";
     }
 
     public function write_to_file($api_key)
@@ -38,7 +38,7 @@ class OdooConnEncryptionFileHandler
         } finally {
             // https://github.com/Jack-Dane/odoo-wp-plugin/issues/2
             // Sometimes (Integration test) the encryption_file isn't seen as a resource to flock
-            // add this check to avoid 500 errors when intially creating data in Wordpress
+            // add this check to avoid 500 errors when initially creating data in WordPress
             // until a better solution is found, this will do.
             if (is_resource($encryption_file)) {
                 flock($encryption_file, LOCK_UN);

--- a/loaded.php
+++ b/loaded.php
@@ -1,5 +1,17 @@
 <?php
 
+function move_existing_encryption_file(): void
+{
+	// Original encryption file path that isn't compatible with WordPress SaaS.
+	// The directory is owned by root in WordPress SaaS.
+	$old_encryption_key_path = ABSPATH . "odoo_conn.key";
+	$new_encryption_key_path = plugin_dir_path(__FILE__) . "odoo_conn.key";
+
+	if (file_exists($old_encryption_key_path)) {
+		rename($old_encryption_key_path, $new_encryption_key_path);
+	}
+}
+
 function odoo_conn_update_db_check()
 {
     require_once(ABSPATH . "wp-admin/includes/upgrade.php");
@@ -48,6 +60,7 @@ function odoo_conn_add_multi_table_column() {
     $wpdb->query($sql);
 }
 
+add_action("plugins_loaded", "move_existing_encryption_file");
 add_action("plugins_loaded", "odoo_conn_update_db_check");
 
 ?>

--- a/tests/php/admin/database_connection/cf7_posts/OdooConnGetContact7Form_Test.php
+++ b/tests/php/admin/database_connection/cf7_posts/OdooConnGetContact7Form_Test.php
@@ -2,8 +2,6 @@
 
 namespace php\admin\database_connection\cf7_posts;
 
-require_once __DIR__ . '/../../../TestClassBrainMonkey.php';
-
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use odoo_conn\admin\database_connection\OdooConnGetContact7Form;
 use PHPUnit\Framework\TestCase;

--- a/tests/php/encryption/OdooConnEncryptionFileHandler_read_from_file_Test.php
+++ b/tests/php/encryption/OdooConnEncryptionFileHandler_read_from_file_Test.php
@@ -3,10 +3,9 @@
 namespace odoo_conn\tests\OdooConnEncryptionFileHandler_Test;
 
 use odoo_conn\encryption\OdooConnEncryptionFileHandler;
-use \org\bovigo\vfs\vfsStream;
-use \PHPUnit\Framework\TestCase;
-
-define("ABSPATH", "vfs://root/");
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Brain\Monkey\Functions;
 
 require_once(__DIR__ . "/../../../encryption.php");
 
@@ -15,13 +14,18 @@ class OdooConnEncryptionFileHandler_read_from_file_Test extends TestCase
 
     public function setUp(): void
     {
+		if (!defined("ABSPATH")) {
+			define("ABSPATH", "vfs://root/");
+		}
+		Functions\when("plugin_dir_path")->justReturn("vfs://root/plugins/odoo-wp-plugin/");
+
         $this->root = vfsStream::setup("root", 0777);
         $this->file_handler = new OdooConnEncryptionFileHandler();
     }
 
     public function test_existing_file()
     {
-        vfsStream::newFile("odoo_conn.key")->at($this->root)->setContent("abc");
+        vfsStream::newFile("plugins/odoo-wp-plugin/odoo_conn.key")->at($this->root)->setContent("abc");
 
         $key = $this->file_handler->read_from_file();
 
@@ -30,7 +34,7 @@ class OdooConnEncryptionFileHandler_read_from_file_Test extends TestCase
 
     public function test_non_existing_file()
     {
-        $this->assertFalse($this->root->hasChild("odoo_conn.key"));
+        $this->assertFalse($this->root->hasChild("plugins/odoo-wp-plugin/odoo_conn.key"));
 
         $key = $this->file_handler->read_from_file();
 

--- a/tests/php/loaded/move_existing_encryption_file_test.php
+++ b/tests/php/loaded/move_existing_encryption_file_test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace php\loaded;
+require_once __DIR__ . "/../TestClassBrainMonkey.php";
+
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use org\bovigo\vfs\vfsStream;
+use TestClassBrainMonkey;
+
+class move_existing_encryption_file_test extends TestClassBrainMonkey
+{
+
+	use MockeryPHPUnitIntegration;
+
+	function setUp(): void
+	{
+		parent::setUp();
+
+		if (!defined("ABSPATH")) {
+			define("ABSPATH", "vfs://root/");
+		}
+		Functions\when("plugin_dir_path")->justReturn("vfs://root/plugins/odoo-wp-plugin/");
+
+		require_once __DIR__ . "/../../../loaded.php";
+
+		$this->root = vfsStream::setup("root", 0777);
+		vfsStream::newDirectory("/plugins/odoo-wp-plugin/")->at($this->root);
+	}
+
+	function test_key_file_moved()
+	{
+		vfsStream::newFile("odoo_conn.key")->at($this->root)->setContent("key");
+
+		move_existing_encryption_file();
+
+		$this->assertTrue(file_exists("vfs://root/plugins/odoo-wp-plugin/odoo_conn.key"));
+		$this->assertFalse(file_exists("vfs://root/odoo_conn.key"));
+		$this->assertEquals(
+			"key", $this->root->getChild("plugins/odoo-wp-plugin/odoo_conn.key")->getContent()
+		);
+	}
+
+	function test_old_key_file_does_not_exist()
+	{
+		vfsStream::newFile("plugins/odoo-wp-plugin/odoo_conn.key")->at($this->root)->setContent("key");
+
+		move_existing_encryption_file();
+
+		$this->assertTrue(file_exists("vfs://root/plugins/odoo-wp-plugin/odoo_conn.key"));
+		$this->assertFalse(file_exists("vfs://root/odoo_conn.key"));
+		$this->assertEquals(
+			"key", $this->root->getChild("plugins/odoo-wp-plugin/odoo_conn.key")->getContent()
+		);
+	}
+
+}
+
+?>


### PR DESCRIPTION
* WordPress SaaS's ABS directory is owned by root, the plugin directory is owned by the WordPress user process.
* Move the file on plugin load if it exists, the file should be in the new location.
* Fix the docker compose file to allow the volume to have the same permission of my workstation.
* Amend tests to include use the new encryption key file.

Closes #46 